### PR TITLE
Let Edge represent separate arrow tip status.

### DIFF
--- a/src/confidence_cut.cpp
+++ b/src/confidence_cut.cpp
@@ -104,7 +104,7 @@ void confidenceCut(Environment& environment) {
   auto to_delete = [&environment](EdgeID& id) {
     int X = id.X, Y = id.Y;
     auto info = id.getEdge().shared_info;
-    double I_prime_original = info->Ixy_ui - info->cplx;
+    double I_prime_original = info->Ixy_ui - info->kxy_ui;
     // exp(I_shuffle - I_original)
     auto confidence = exp(-I_prime_original) / info->exp_shuffle;
     if (confidence > environment.conf_threshold) {

--- a/src/orientation.cpp
+++ b/src/orientation.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>  // std::minmax, std::remove, std::transform
 #define _USE_MATH_DEFINES
 #include <cmath>
-#include <tuple>  // std::tie
 #include <map>
 
 #include "get_information.h"
@@ -27,31 +26,16 @@ using namespace miic::utility;
 namespace {
 
 bool acceptProba(double proba, double ori_proba_ratio) {
-  if (proba <= 0.5) return false;
   return (1 - proba) / proba < ori_proba_ratio;
 }
 
 // y2x: probability that there is an arrow from node y to x
 // x2y: probability that there is an arrow from node x to y
 void updateAdj(Environment& env, int x, int y, double y2x, double x2y) {
-  double lower, higher;
-  std::tie(lower, higher) = std::minmax(y2x, x2y);
-  // No arrowhead
-  if (higher <= 0.5) return;
-  // Only one arrowhead
-  if (lower <= 0.5) {
-    if (y2x == higher && acceptProba(y2x, env.ori_proba_ratio)) {
-      env.edges(x, y).status = -2;
-      env.edges(y, x).status = 2;
-    } else if (acceptProba(x2y, env.ori_proba_ratio)) {
-      env.edges(x, y).status = 2;
-      env.edges(y, x).status = -2;
-    }
-  } else if (acceptProba(x2y, env.ori_proba_ratio) &&
-             acceptProba(y2x, env.ori_proba_ratio)) {
-    env.edges(x, y).status = 6;
-    env.edges(y, x).status = 6;
-  }
+  if (acceptProba(x2y, env.ori_proba_ratio))
+    env.edges(x, y).status = 2;
+  if (acceptProba(y2x, env.ori_proba_ratio))
+    env.edges(y, x).status = 2;
 }
 
 }  // anonymous namespace

--- a/src/skeleton.cpp
+++ b/src/skeleton.cpp
@@ -29,13 +29,13 @@ int initializeEdge(Environment& environment, int X, int Y) {
       environment.data_numeric, environment.data_numeric_idx, environment);
   info->Nxy = xy.n_samples;
   info->Ixy = xy.I;
-  info->cplx_no_u = xy.k;
+  info->kxy = xy.k;
 
   info->Nxy_ui = info->Nxy;
   info->Ixy_ui = info->Ixy;
-  info->cplx = info->cplx_no_u;
+  info->kxy_ui = info->kxy;
 
-  double shifted_mi = info->Ixy - info->cplx_no_u;
+  double shifted_mi = info->Ixy - info->kxy;
   if (!environment.no_init_eta) shifted_mi -= environment.log_eta;
 
   if (shifted_mi <= 0) {
@@ -190,7 +190,7 @@ bool searchForConditionalIndependence(Environment& environment) {
         environment.data_numeric, environment.data_numeric_idx, environment);
     top_info->Nxy_ui = res.n_samples;
     top_info->Ixy_ui = res.I;
-    top_info->cplx = res.k;
+    top_info->kxy_ui = res.k;
 
     if (environment.verbose) {
       Rcout << "Edge " << iter_count << ": " << environment.nodes[X].name
@@ -200,9 +200,9 @@ bool searchForConditionalIndependence(Environment& environment) {
         Rcout << environment.nodes[u].name << ", ";
       Rcout << "}\n";
       Rcout << "Ixy_ui " << top_info->Ixy_ui << "\n";
-      Rcout << "kxy_ui " << top_info->cplx << "\n";
+      Rcout << "kxy_ui " << top_info->kxy_ui << "\n";
     }
-    if (top_info->Ixy_ui - top_info->cplx - environment.log_eta <= 0) {
+    if (top_info->Ixy_ui - top_info->kxy_ui - environment.log_eta <= 0) {
       // Conditional independence found, remove edge
       unsettled_list.erase(it_max);
       environment.edges(X, Y).status = 0;

--- a/src/structure.h
+++ b/src/structure.h
@@ -162,7 +162,7 @@ struct EdgeSharedInfo {
   // Conditional mutual information
   double Ixy_ui = 0;
   // Complexity with conditioning
-  double cplx = 0;
+  double kxy_ui = 0;
   // Count of joint factors without NA
   int Nxy_ui = -1;
   // 1 or 0. An edge is by default connected.
@@ -170,7 +170,7 @@ struct EdgeSharedInfo {
   // Mutual information without conditioning
   double Ixy = 0;
   // Complexity without conditioning
-  double cplx_no_u = 0;
+  double kxy = 0;
   // Count of joint factors without NA
   int Nxy = -1;
   // if doing shuffling, exp(-I_shuffle)
@@ -184,7 +184,7 @@ struct EdgeSharedInfo {
     top_z = -1;
     Rxyz_ui = 0;
     Ixy_ui = Ixy;
-    cplx = cplx_no_u;
+    kxy_ui = kxy;
     Nxy_ui = Nxy;
     connected = 1;
   }
@@ -194,7 +194,7 @@ struct EdgeSharedInfo {
     top_z = -1;
     Rxyz_ui = 0;
     Ixy_ui = Ixy;
-    cplx = cplx_no_u;
+    kxy_ui = kxy;
     Nxy_ui = Nxy;
     connected = 1;
   }
@@ -206,13 +206,12 @@ struct Node {
 };
 
 struct Edge {
-  // Edge is stored in Edge** edges
-  // Status code (suppose edges(X, Y)):
+  // For a pair of nodes (X, Y), status describes the arrow tip of the edge
+  // (X *-* Y) at the Y side ('*' means either head '>' or tail '-')
+  // Status code
   // 0: not connected;
-  // 1: connected and undirected;
-  // 2: connected directed X -> Y;
-  // -2: connected directed X <- Y;
-  // 6: connected bidirected X <-> Y;
+  // 1: tail (X *-- Y);
+  // 2: head (X *-> Y);
   short int status;       // Current status.
   short int status_init;  // Status after initialization.
   short int status_prev;  // Status in the previous iteration.

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -16,8 +16,7 @@ inline double getLapInterval(TimePoint start_time) {
   return second(std::chrono::steady_clock::now() - start_time).count();
 }
 
-std::vector<std::vector<int>> getAdjMatrix(
-    const structure::Grid2d<structure::Edge>&);
+std::vector<int> getAdjMatrix(const structure::Grid2d<structure::Edge>&);
 
 std::string toNameString(
     const std::vector<structure::Node>&, const std::vector<int>&);


### PR DESCRIPTION
- Now status in the Edge class can only have three possible values:
  `0` for disconnected, `1` for arrow tail and `2` for arrow head. No
  longer use `6` to represent double-headed edges (`X <-> Y`) and `-2`
  to represent tail.

- CycleTracker now tracks whole adj matrix instead of only the lower
  triangular part.

As a result, the merge of two edges `X --> Y` and `X <-> Y` will be
`X --> Y`, instead of `X --- Y`. This doesn't effect the export of adj
matrix to R (`-2` and `6` are still used).

Resolves #62