### PR TITLE
Fix incorrect initialization of maxbins and initbins

### DIFF
--- a/R/discretizeMutual.R
+++ b/R/discretizeMutual.R
@@ -188,16 +188,6 @@ discretizeMutual <- function(X,
     )
   }
 
-  initbins <- NULL
-  if ((initbins > length(X)) || is.null(initbins)) {
-    initbins <- round(length(X)**(1 / 3))
-  }
-
-  if ((maxbins > length(X)) ||
-    is.null(maxbins) || (maxbins < initbins)) {
-    maxbins <- 5 * initbins
-  }
-
   # Remove rows for which any input vector is NA
   matrix_u_NA <- matrix()
   NArows <- logical(length(X))
@@ -230,6 +220,16 @@ discretizeMutual <- function(X,
     for (k in 1:ncol(matrix_u)) {
       matrix_u_NA[, k] <- matrix_u[!NArows, k]
     }
+  }
+
+  initbins <- NULL
+  if ((initbins > length(X)) || is.null(initbins)) {
+    initbins <- min(30, round(length(X)**(1 / 3)))
+  }
+
+  if ((maxbins > length(X)) ||
+    is.null(maxbins) || (maxbins < initbins)) {
+    maxbins <- min(length(X), 5 * initbins)
   }
 
   # Converting factors to discrete numerical variables

--- a/R/miic.reconstruct.R
+++ b/R/miic.reconstruct.R
@@ -68,7 +68,7 @@ miic.reconstruct <- function(input_data = NULL,
     "ori_proba_ratio" = ori_proba_ratio,
     "propagation" = propagation,
     "test_mar" = test_mar,
-    "max_bins" = 50,
+    "max_bins" = min(50, n_samples),
     "var_names" = var_names,
     "verbose" = verbose
   )

--- a/src/r_cpp_interface.cpp
+++ b/src/r_cpp_interface.cpp
@@ -105,6 +105,8 @@ void setEnvironmentFromR(const Rcpp::List& input_data,
 
   if (arg_list.containsElementNamed("max_bins"))
     environment.maxbins = as<int>(arg_list["max_bins"]);
+  if (environment.maxbins > n_samples)
+    environment.maxbins = n_samples;
 
   if (arg_list.containsElementNamed("n_threads"))
     environment.n_threads = as<int>(arg_list["n_threads"]);


### PR DESCRIPTION
Before this fix, if the dataset contains too few not-all-NA samples, the `maxbins` and `initbins` could be larger than `n_samples`, leading to incorrect memory allocation (not enough memory).