### PR TITLE
Adds new rule to error column in orientation probabilities file.

### DIFF
--- a/src/orientation.cpp
+++ b/src/orientation.cpp
@@ -24,7 +24,7 @@ using namespace miic::structure;
 using namespace miic::utility;
 
 namespace {
-// If I3 is that small, it will be considered as zero
+
 constexpr double kEpsI3 = 1.0e-10;
 
 bool acceptProba(double proba, double ori_proba_ratio) {

--- a/src/orientation.cpp
+++ b/src/orientation.cpp
@@ -137,7 +137,8 @@ vector<vector<string>> orientationProbability(Environment& environment) {
     if ((info_int != 0 && info_sign != proba_sign) ||
         (info_int == 0 && proba_sign == -1))
       error = "1";
-
+    if (I3_list[i] == 0)
+      error = "0";
     using std::to_string;
     orientations.emplace_back(std::initializer_list<string>{
         environment.nodes[triple[0]].name,

--- a/src/orientation.cpp
+++ b/src/orientation.cpp
@@ -24,7 +24,7 @@ using namespace miic::structure;
 using namespace miic::utility;
 
 namespace {
-
+// If I3 is that small, it will be considered as zero
 constexpr double kEpsI3 = 1.0e-10;
 
 bool acceptProba(double proba, double ori_proba_ratio) {


### PR DESCRIPTION
Hervé requested to change the assignment of error 0 / 1 in the orientation probability file so that if NI3 == 0, this should not be considered as an error.