### PR TITLE
Comparison scheme to choose a top Z in case of ties

### DIFF
--- a/src/computation_cache.h
+++ b/src/computation_cache.h
@@ -123,6 +123,7 @@ struct ScoreKey {
 using MutualInfoMap = std::map<MutualInfoKey, InfoBlock>;
 using Info3PointMap = std::map<Info3PointKey, double>;
 using ScoreMap = std::map<ScoreKey, double>;
+using EntropyMap = std::map<ScoreKey, double>;
 
 class InfoScoreCache {
  public:
@@ -168,10 +169,23 @@ class InfoScoreCache {
     score_map_.insert({ScoreKey(X, Y, Z, ui), score});
   }
 
+  pair<double, bool> getEntropy(int X, int Y, int Z, const vector<int>& ui) {
+    auto it = entropy_map_.find(ScoreKey(X, Y, Z, ui));
+    bool found = it != entropy_map_.end();
+    return std::make_pair(found ? it->second : 0, found);
+  }
+
+  void saveEntropy(int X, int Y, int Z, const vector<int>& ui, double H) {
+    // Already in critical block
+    entropy_map_.insert({ScoreKey(X, Y, Z, ui), H});
+  }
+
+
  private:
   MutualInfoMap mi_map_;
   Info3PointMap i3_map_;
   ScoreMap score_map_;
+  EntropyMap entropy_map_;
 };
 
 struct CompCache {

--- a/src/computation_cache.h
+++ b/src/computation_cache.h
@@ -169,15 +169,15 @@ class InfoScoreCache {
     score_map_.insert({ScoreKey(X, Y, Z, ui), score});
   }
 
-  pair<double, bool> getEntropy(int X, int Y, int Z, const vector<int>& ui) {
-    auto it = entropy_map_.find(ScoreKey(X, Y, Z, ui));
+  pair<double, bool> getEntropy(int X, int Y, int Z) {
+    auto it = entropy_map_.find(ScoreKey(X, Y, Z, vector<int>()));
     bool found = it != entropy_map_.end();
     return std::make_pair(found ? it->second : 0, found);
   }
 
-  void saveEntropy(int X, int Y, int Z, const vector<int>& ui, double H) {
+  void saveEntropy(int X, int Y, int Z, double H) {
     // Already in critical block
-    entropy_map_.insert({ScoreKey(X, Y, Z, ui), H});
+    entropy_map_.insert({ScoreKey(X, Y, Z, vector<int>()), H});
   }
 
 


### PR DESCRIPTION
Tied scores can happen with some data (e.g. discretizing semi-continuous
variables) and cause the final choice of contributing nodes to be
order-dependent. This order can have slight variations depending on the
number of threads with a dynamic schedule.

In the case of a tie, we need an order-independent test to choose a new top Z.
This commit implements a comparison between the Zs' entropies by computing
I(X;Z)+I(Y;Z), and another test that depends on the seeded RNG if those sums
are also equal.