### PR TITLE
Rework consensus graph and causal status.

### DIFF
--- a/R/miic.R
+++ b/R/miic.R
@@ -80,11 +80,18 @@
 #' procedure relyes on probabilities; for more details, see Verny \emph{et al.}, PLoS Comp. Bio. 2017).
 #' If set to FALSE the orientation step is not performed.
 #'
-#' @param ori_proba_ratio [a floating point between 0 and 1] When orienting an
-#' edge according to the probability of orientation, the threshold to accept the
-#' orientation. For a given edge, denote by p > 0.5 the probability of
-#' orientation, the orientation is accepted if (1 - p) / p < ori_proba_ratio.
-#' 0 means reject all orientations, 1 means accept all orientations.
+#' @param ori_proba_ratio [a floating point between 0 and 1] The threshold when
+#' deducing the type of an edge tip (head/tail) from the probability of
+#' orientation. For a given edge tip, denote by p the probability of it being a
+#' head, the orientation is accepted if (1 - p) / p < ori_proba_ratio. 0 means
+#' reject all orientations, 1 means accept all orientations.
+#'
+#' @param ori_consensus_ratio [a floating point between 0 and 1] The threshold
+#' when deducing the type of an consensus edge tip (head/tail) from the average
+#' probability of orientation. For a given edge tip, denote by p the probability
+#' of it being a head, the orientation is accepted if (1 - p) / p <
+#' ori_consensus_ratio. 0 means reject all orientations, 1 means accept all
+#' orientations.
 #'
 #' @param propagation [a boolean value]
 #' If set to FALSE, the skeleton is partially oriented with only the
@@ -150,18 +157,20 @@
 #' is set to "skeleton" or "orientation", the maximum number of iterations
 #' allowed when trying to find a consistent graph. Set to 100 by default.
 #'
-#' @param consensus_threshold [a floating point between 0.5 and 1.0]
-#' When the \emph{consistent} parameter is set to "skeleton" or "orientation",
-#' and when the result graph is inconsistent, or is a union of more than one
-#' inconsistent graphs, a consensus graph will be produced based on a pool of
-#' graphs. If the result graph is inconsistent, then the pool is made of
-#' [max_iteration] graphs from the iterations, otherwise it is made of those
-#' graphs in the union. In the consensus graph, the status of each edge is
-#' determined as follows: Choose from the pool the most probable status. For
-#' example, if the pool contains [A, B, B, B, C], then choose status B, if the
-#' frequency of presence of B (0.6 in the example) is equal to or higher than
-#' [consensus_threshold], then set B as the status of the edge in the consensus
-#' graph, otherwise set undirected edge as the status. Set to 0.8 by default.
+#' @param consensus_threshold [a floating point between 0.5 and 1.0] When the
+#' \emph{consistent} parameter is set to "skeleton" or "orientation", and when
+#' the result graph is inconsistent, or is a union of more than one inconsistent
+#' graphs, a consensus graph will be produced based on a pool of graphs. If the
+#' result graph is inconsistent, then the pool is made of [max_iteration] graphs
+#' from the iterations, otherwise it is made of those graphs in the union. In
+#' the consensus graph, an edge is present when the proportion of non-zero
+#' status in the pool is above the threshold. For example, if the pool contains
+#' [A, B, B, 0, 0], where "A", "B" are different status of the edge and "0"
+#' indicates the absence of the edge. Then the edge is set to connected ("1") if
+#' the proportion of non-zero status (0.6 in the example) is equal to or higher
+#' than [consensus_threshold]. (When set to connected, the orientation of the
+#' edge will be further determined by the average probability of orientation.)
+#' Set to 0.8 by default.
 #'
 #' @param verbose [a boolean value] If TRUE, debugging output is printed.
 #'
@@ -326,6 +335,7 @@ miic <- function(input_data,
                  cplx = c("nml", "mdl"),
                  orientation = TRUE,
                  ori_proba_ratio = 1,
+                 ori_consensus_ratio = 1,
                  propagation = TRUE,
                  latent = c("no", "yes", "orientation"),
                  n_eff = -1,
@@ -528,6 +538,9 @@ miic <- function(input_data,
       true_edges = true_edges,
       state_order = state_order,
       consensus_threshold = consensus_threshold,
+      ori_consensus_ratio = ori_consensus_ratio,
+      latent = latent != "no",
+      propagation = propagation,
       verbose = verbose
     )
   }

--- a/R/miic.R
+++ b/R/miic.R
@@ -335,7 +335,7 @@ miic <- function(input_data,
                  cplx = c("nml", "mdl"),
                  orientation = TRUE,
                  ori_proba_ratio = 1,
-                 ori_consensus_ratio = 1,
+                 ori_consensus_ratio = NULL,
                  propagation = TRUE,
                  latent = c("no", "yes", "orientation"),
                  n_eff = -1,
@@ -420,6 +420,10 @@ miic <- function(input_data,
 
   if (orientation != TRUE && orientation != FALSE) {
     stop("The orientation type is not correct. Allowed types are TRUE or FALSE")
+  }
+
+  if (is.null(ori_consensus_ratio)) {
+    ori_consensus_ratio <- ori_proba_ratio
   }
 
   if (verbose) {

--- a/R/miic.reconstruct.R
+++ b/R/miic.reconstruct.R
@@ -112,14 +112,31 @@ miic.reconstruct <- function(input_data = NULL,
   res$edges <- df
 
   #  adj_matrix
-  res$adj_matrix <- matrix(unlist(res$adj_matrix), nrow = length(input_data), byrow = TRUE)
+  res$adj_matrix <- matrix(unlist(res$adj_matrix), nrow = length(input_data),
+                           byrow = TRUE)
   colnames(res$adj_matrix) <- var_names
   rownames(res$adj_matrix) <- var_names
+
+  #  proba_adj_matrix
+  res$proba_adj_matrix <- matrix(unlist(res$proba_adj_matrix),
+                                 nrow = length(input_data), byrow = TRUE)
+  colnames(res$proba_adj_matrix) <- var_names
+  rownames(res$proba_adj_matrix) <- var_names
 
   # adj_matrices (when consistent parameter is turned on)
   if (length(res$adj_matrices) > 0) {
     res$adj_matrices <- matrix(unlist(res$adj_matrices),
                                ncol = length(res$adj_matrices))
+  }
+
+  # proba_adj_matrices (when consistent parameter is turned on)
+  if (length(res$proba_adj_matrices) > 0) {
+    res$proba_adj_matrices <- matrix(unlist(res$proba_adj_matrices),
+                               ncol = length(res$proba_adj_matrices))
+    res$proba_adj_matrices[res$proba_adj_matrices == -1] <- NA
+    adj_average <- rowMeans(res$proba_adj_matrices, na.rm = TRUE)
+    res$proba_adj_average <- matrix(unlist(adj_average),
+                                    nrow = length(input_data), byrow = TRUE)
   }
 
   # save time

--- a/man/miic.Rd
+++ b/man/miic.Rd
@@ -13,6 +13,7 @@ miic(
   cplx = c("nml", "mdl"),
   orientation = TRUE,
   ori_proba_ratio = 1,
+  ori_consensus_ratio = 1,
   propagation = TRUE,
   latent = c("no", "yes", "orientation"),
   n_eff = -1,
@@ -89,11 +90,18 @@ of the conditional 3-point information of unshielded triples. The propagation
 procedure relyes on probabilities; for more details, see Verny \emph{et al.}, PLoS Comp. Bio. 2017).
 If set to FALSE the orientation step is not performed.}
 
-\item{ori_proba_ratio}{[a floating point between 0 and 1] When orienting an
-edge according to the probability of orientation, the threshold to accept the
-orientation. For a given edge, denote by p > 0.5 the probability of
-orientation, the orientation is accepted if (1 - p) / p < ori_proba_ratio.
-0 means reject all orientations, 1 means accept all orientations.}
+\item{ori_proba_ratio}{[a floating point between 0 and 1] The threshold when
+deducing the type of an edge tip (head/tail) from the probability of
+orientation. For a given edge tip, denote by p the probability of it being a
+head, the orientation is accepted if (1 - p) / p < ori_proba_ratio. 0 means
+reject all orientations, 1 means accept all orientations.}
+
+\item{ori_consensus_ratio}{[a floating point between 0 and 1] The threshold
+when deducing the type of an consensus edge tip (head/tail) from the average
+probability of orientation. For a given edge tip, denote by p the probability
+of it being a head, the orientation is accepted if (1 - p) / p <
+ori_consensus_ratio. 0 means reject all orientations, 1 means accept all
+orientations.}
 
 \item{propagation}{[a boolean value]
 If set to FALSE, the skeleton is partially oriented with only the
@@ -148,18 +156,20 @@ the network. See (Li \emph{et al.}, NeurIPS 2019) for details.}
 is set to "skeleton" or "orientation", the maximum number of iterations
 allowed when trying to find a consistent graph. Set to 100 by default.}
 
-\item{consensus_threshold}{[a floating point between 0.5 and 1.0]
-When the \emph{consistent} parameter is set to "skeleton" or "orientation",
-and when the result graph is inconsistent, or is a union of more than one
-inconsistent graphs, a consensus graph will be produced based on a pool of
-graphs. If the result graph is inconsistent, then the pool is made of
-[max_iteration] graphs from the iterations, otherwise it is made of those
-graphs in the union. In the consensus graph, the status of each edge is
-determined as follows: Choose from the pool the most probable status. For
-example, if the pool contains [A, B, B, B, C], then choose status B, if the
-frequency of presence of B (0.6 in the example) is equal to or higher than
-[consensus_threshold], then set B as the status of the edge in the consensus
-graph, otherwise set undirected edge as the status. Set to 0.8 by default.}
+\item{consensus_threshold}{[a floating point between 0.5 and 1.0] When the
+\emph{consistent} parameter is set to "skeleton" or "orientation", and when
+the result graph is inconsistent, or is a union of more than one inconsistent
+graphs, a consensus graph will be produced based on a pool of graphs. If the
+result graph is inconsistent, then the pool is made of [max_iteration] graphs
+from the iterations, otherwise it is made of those graphs in the union. In
+the consensus graph, an edge is present when the proportion of non-zero
+status in the pool is above the threshold. For example, if the pool contains
+[A, B, B, 0, 0], where "A", "B" are different status of the edge and "0"
+indicates the absence of the edge. Then the edge is set to connected ("1") if
+the proportion of non-zero status (0.6 in the example) is equal to or higher
+than [consensus_threshold]. (When set to connected, the orientation of the
+edge will be further determined by the average probability of orientation.)
+Set to 0.8 by default.}
 
 \item{verbose}{[a boolean value] If TRUE, debugging output is printed.}
 }

--- a/man/miic.Rd
+++ b/man/miic.Rd
@@ -13,7 +13,7 @@ miic(
   cplx = c("nml", "mdl"),
   orientation = TRUE,
   ori_proba_ratio = 1,
-  ori_consensus_ratio = 1,
+  ori_consensus_ratio = NULL,
   propagation = TRUE,
   latent = c("no", "yes", "orientation"),
   n_eff = -1,

--- a/src/confidence_cut.cpp
+++ b/src/confidence_cut.cpp
@@ -111,6 +111,8 @@ void confidenceCut(Environment& environment) {
       info->connected = 0;
       environment.edges(X, Y).status = 0;
       environment.edges(Y, X).status = 0;
+      environment.edges(X, Y).proba_head = -1;
+      environment.edges(Y, X).proba_head = -1;
       return true;
     } else {
       return false;

--- a/src/cycle_tracker.cpp
+++ b/src/cycle_tracker.cpp
@@ -80,6 +80,14 @@ vector<vector<int>> CycleTracker::getAdjMatrices(int size) {
   return adj_matrices;
 }
 
+vector<vector<double>> CycleTracker::getProbaAdjMatrices(int size) {
+  vector<vector<double>> adj_matrices;
+  for (auto i = iterations_.begin(); i != iterations_.begin() + size; ++i) {
+    adj_matrices.push_back(i->proba_adj_matrix_1d);
+  }
+  return adj_matrices;
+}
+
 }  // namespace detail
 }  // namespace reconstruction
 }  // namespace miic

--- a/src/cycle_tracker.h
+++ b/src/cycle_tracker.h
@@ -17,7 +17,7 @@ namespace reconstruction {
 namespace detail {
 using std::vector;
 using namespace structure;
-using utility::getAdjMatrix;
+using namespace utility;
 
 // convert 2d index in a n_nodes * n_nodes grid to 1d index
 inline int getIndex1D(int i, int j, int n_nodes) { return j + i * n_nodes; }
@@ -36,6 +36,7 @@ class CycleTracker {
   CycleTracker(Grid2d<Edge>& edges, const vector<EdgeID>& edge_list)
       : edges_(edges), edge_list_(edge_list) {}
   vector<vector<int>> getAdjMatrices(int size);
+  vector<vector<double>> getProbaAdjMatrices(int size);
   int getCycleSize() { return cycle_size; }
   // check if a cycle exists between the current and the past iterations
   bool hasCycle();
@@ -47,9 +48,12 @@ class CycleTracker {
     // value: status of edge in the previous iteration
     std::map<int, int> changed_edges;
     vector<int> adj_matrix_1d;
+    vector<double> proba_adj_matrix_1d;
 
     Iteration(const Grid2d<Edge>& edges, int i)
-        : index(i), adj_matrix_1d(getAdjMatrix(edges)) {
+        : index(i),
+          adj_matrix_1d(getAdjMatrix(edges)),
+          proba_adj_matrix_1d(getProbaAdjMatrix(edges)) {
       int n_nodes = edges.n_rows();
       for (int i = 0; i < n_nodes; ++i) {
         for (int j = 0; j < n_nodes; ++j) {

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -40,6 +40,7 @@ Environment::Environment(int n_samples, int n_nodes, vector<int> vec_numeric,
         // information with other nodes is null.
         edges(i, j).status = 0;
         edges(i, j).status_prev = 0;
+        edges(i, j).proba_head = -1;
       } else {
         // Initialise all other edges.
         edges(i, j).status = 1;
@@ -50,6 +51,7 @@ Environment::Environment(int n_samples, int n_nodes, vector<int> vec_numeric,
   for (int i = 0; i < n_nodes; ++i) {
     edges(i, i).status = 0;
     edges(i, i).status_prev = 0;
+    edges(i, i).proba_head = -1;
   }
 }
 
@@ -59,8 +61,10 @@ void Environment::readBlackbox(const Grid2d<int>& node_list) {
     const auto pair = node_list.getConstRow(i);
     edges(pair[0], pair[1]).status = 0;
     edges(pair[0], pair[1]).status_prev = 0;
+    edges(pair[0], pair[1]).proba_head = -1;
     edges(pair[1], pair[0]).status = 0;
     edges(pair[1], pair[0]).status_prev = 0;
+    edges(pair[1], pair[0]).proba_head = -1;
   }
 }
 

--- a/src/orientation.cpp
+++ b/src/orientation.cpp
@@ -34,8 +34,10 @@ bool acceptProba(double proba, double ori_proba_ratio) {
 // y2x: probability that there is an arrow from node y to x
 // x2y: probability that there is an arrow from node x to y
 void updateAdj(Environment& env, int x, int y, double y2x, double x2y) {
+  env.edges(x, y).proba_head = x2y;
   if (acceptProba(x2y, env.ori_proba_ratio))
     env.edges(x, y).status = 2;
+  env.edges(y, x).proba_head = y2x;
   if (acceptProba(y2x, env.ori_proba_ratio))
     env.edges(y, x).status = 2;
 }
@@ -124,8 +126,8 @@ vector<vector<string>> orientationProbability(Environment& environment) {
     updateAdj(environment, triple[1], triple[2], probas[2], probas[3]);
   }
   // Write output
-  vector<vector<string>> orientations{
-      {"source1", "p1", "p2", "target", "p3", "p4", "source2", "NI3", "Error"}};
+  vector<vector<string>> orientations{{"source1", "p1", "p2", "target", "p3",
+      "p4", "source2", "NI3", "Conflict"}};
   for (size_t i = 0; i < triples.size(); i++) {
     const auto& triple = triples[i];
     const auto& probas = probas_list[i];
@@ -134,10 +136,10 @@ vector<vector<string>> orientationProbability(Environment& environment) {
     int info_sign = (I3 > 0) - (I3 < 0);
     // -1: v-structure, 1: non-v-structure
     int proba_sign = (probas[1] > 0.5 && probas[2] > 0.5) ? -1 : 1;
-    // error if I3 is non-zero but info_sign is different from proba_sign,
+    // conflict if I3 is non-zero but info_sign is different from proba_sign,
     // since positive I3 indicates non-v-structure and negative I3 indicates
     // v-structure.
-    string error = (I3 != 0 && info_sign != proba_sign) ? "1" : "0";
+    string conflict = (I3 != 0 && info_sign != proba_sign) ? "1" : "0";
 
     using std::to_string;
     orientations.emplace_back(std::initializer_list<string>{
@@ -146,7 +148,7 @@ vector<vector<string>> orientationProbability(Environment& environment) {
         environment.nodes[triple[1]].name,
         to_string(probas[2]), to_string(probas[3]),
         environment.nodes[triple[2]].name,
-        to_string(I3_list[i]), error});
+        to_string(I3_list[i]), conflict});
   }
   return orientations;
 }

--- a/src/r_cpp_interface.cpp
+++ b/src/r_cpp_interface.cpp
@@ -88,8 +88,10 @@ void setEnvironmentFromR(const Rcpp::List& input_data,
         if (environment.is_contextual[j]) {
           environment.edges(i, j).status = 0;
           environment.edges(i, j).status_prev = 0;
+          environment.edges(i, j).proba_head = -1;
           environment.edges(j, i).status = 0;
           environment.edges(j, i).status_prev = 0;
+          environment.edges(j, i).proba_head = -1;
         }
       }
     }

--- a/src/reconstruct.cpp
+++ b/src/reconstruct.cpp
@@ -66,8 +66,10 @@ List reconstruct(List input_data, List arg_list) {
     // moment of initialization
     for (int i = 0; i < environment.n_nodes; i++) {
       for (int j = 0; j < environment.n_nodes; j++) {
-        environment.edges(i, j).status_prev = environment.edges(i, j).status;
-        environment.edges(i, j).status = environment.edges(i, j).status_init;
+        auto& edge = environment.edges(i, j);
+        edge.status_prev = edge.status;
+        edge.status = edge.status_init;
+        if (edge.status != 0) edge.proba_head = 0.5;
       }
     }
     lap_start = getLapStartTime();
@@ -160,6 +162,7 @@ List reconstruct(List input_data, List arg_list) {
   const auto& time = environment.exec_time;
   List result = List::create(
       _["adj_matrix"]        = getAdjMatrix(environment.edges),
+      _["proba_adj_matrix"]  = getProbaAdjMatrix(environment.edges),
       _["edges"]             = getEdgesInfoTable(environment.edges,
                                    environment.nodes),
       _["orientations.prob"] = orientations,
@@ -170,6 +173,8 @@ List reconstruct(List input_data, List arg_list) {
     int size = is_consistent ? cycle_tracker.getCycleSize()
                              : environment.max_iteration;
     result.push_back(cycle_tracker.getAdjMatrices(size), "adj_matrices");
+    result.push_back(
+        cycle_tracker.getProbaAdjMatrices(size), "proba_adj_matrices");
     result.push_back(is_consistent, "is_consistent");
   }
   delete li_alloc_ptr;

--- a/src/skeleton.cpp
+++ b/src/skeleton.cpp
@@ -47,6 +47,8 @@ int initializeEdge(Environment& environment, int X, int Y) {
     environment.edges(Y, X).status = 0;
     environment.edges(X, Y).status_init = 0;
     environment.edges(Y, X).status_init = 0;
+    environment.edges(X, Y).proba_head = -1;
+    environment.edges(Y, X).proba_head = -1;
   } else {
     info->connected = 1;
     environment.edges(X, Y).status = 1;
@@ -225,6 +227,8 @@ bool searchForConditionalIndependence(Environment& environment) {
       unsettled_list.erase(it_max);
       environment.edges(X, Y).status = 0;
       environment.edges(Y, X).status = 0;
+      environment.edges(X, Y).proba_head = -1;
+      environment.edges(Y, X).proba_head = -1;
       top_info->connected = 0;
     } else {
       // Search for next candidate separating node

--- a/src/structure.h
+++ b/src/structure.h
@@ -212,9 +212,10 @@ struct Edge {
   // 0: not connected;
   // 1: tail (X *-- Y);
   // 2: head (X *-> Y);
-  short int status;       // Current status.
-  short int status_init;  // Status after initialization.
-  short int status_prev;  // Status in the previous iteration.
+  short int status;        // Current status.
+  short int status_init;   // Status after initialization.
+  short int status_prev;   // Status in the previous iteration.
+  double proba_head{0.5};  // Probability that the arrow tip is head (X *-> Y)
   std::shared_ptr<EdgeSharedInfo> shared_info;
 };
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -220,6 +220,17 @@ vector<int> getAdjMatrix(const Grid2d<Edge>& edges) {
   return adj;
 }
 
+vector<double> getProbaAdjMatrix(const Grid2d<Edge>& edges) {
+  vector<double> adj(edges.size(), 0.5);
+  size_t n_nodes = edges.n_rows();
+  for (size_t X = 0; X < n_nodes; ++X) {
+    for (size_t Y = 0; Y < n_nodes; ++Y) {
+      adj[Y + X * n_nodes] = edges(X, Y).proba_head;
+    }
+  }
+  return adj;
+}
+
 string toNameString(const vector<Node>& nodes, const vector<int>& vec) {
   if (vec.empty()) {
     return "NA";

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -17,6 +17,8 @@ inline double getLapInterval(TimePoint start_time) {
 }
 
 std::vector<int> getAdjMatrix(const structure::Grid2d<structure::Edge>&);
+std::vector<double> getProbaAdjMatrix(
+    const structure::Grid2d<structure::Edge>&);
 
 std::string toNameString(
     const std::vector<structure::Node>&, const std::vector<int>&);


### PR DESCRIPTION
* Introduce adjacency matrix of orientation probability (`proba_adj_matrix`) to keep track of the probability (`[0, 1]`) of an edge tip being a head during each iteration. Set to -1 when the edge is not present.
* Introduce average adjacency matrix of orientation probability (`proba_adj_average`). When sep-set consistency is not required or when the consistent cycle contains only one graph, it is `proba_adj_matrix` of the last graph, otherwise it is the average (excluding "-1") of all `proba_adj_matrices` in the consistent cycle.
* Introduce new parameter `ori_consensus_ratio`, similar to `ori_proba_ratio`, to determine the type of tip (head/tail) of consensus edges
* Rework algorithm for `consensus` status. Introduce new algorithm for `consensus` status based on `consensus_threshold`, `proba_adj_average` and `proba_consensus_ratio`:
  - `consensus_threshold` now controls whether an edge is present (when the proportion of non-zero status is above the threshold) or absent (when otherwise) in the consensus graph, no longer controls the type of edge tip.
  - When a consensus edge is present, a tip is set as head if its average orientation probability `p` (from `proba_adj_average`) satisfies `(1 - p) / p < ori_consensus_ratio`.
  - For a pair `(X, Y)`, `consensus` status is
    - `0` if edge is absent
    - `1` if `(X --- Y)`
    - `2` if `(X --> Y)`
    - `-2` if `(X <-- Y)`
    - `6` if `(X <-> Y)`
* Remove conditions for `is_causal` introduced in (#80). Introduce new conditions for `is_causal` based on `proba_adj_average` and `proba_consensus_ratio`. For an edge `(X *-* Y)` (either in the final, consistent or consensus graph) with average orientation probabilities `px` and `py`, `is_causal` is set to `TRUE` when either of the following conditions is satisfied:
  - the edge status is `(X --> Y)` and `(px, py)` satisfies `(1 - py) / py < ori_consensus_ratio` and `px / (1 - px) < ori_consensus_ratio`.
  - the edge status is `(X <-- Y)` and `(px, py)` satisfies `(1 - px) / px < ori_consensus_ratio` and `py / (1 - py) < ori_consensus_ratio`.

  Otherwise `is_causal` is set to `FALSE`. When the edge is absent, or the parameter `latent` is set to "no", or the parameter `propagation` is set to "TRUE", `is_causal` is set to `NA`.
* Rename the column `isCausal` to `is_causal` in `all.edges.summary`, add new column `is_causal_consensus`.
* Reword parameter descriptions for `consensus_threshold` and `ori_proba_ratio`.
* Rename "Error" to "Conflict" in the edge probability table.