### PR TITLE
Refactor orientation probability functions

### DIFF
--- a/src/proba_orientation.cpp
+++ b/src/proba_orientation.cpp
@@ -204,56 +204,54 @@ vector<ProbaArray> getOriProbasList(const vector<Triple>& triples,
     if (X == -1 && Y == -1) continue;  // No score updated, goto next triple
     // Update scores of all triples in the list sharing edge with the top triple
     for (auto i : order) {
+      int w2z_index{-1}, z2w_index{-1};   // shared edge markers of triples[i]
+      double w2z_value{0}, z2w_value{0};  // final scores of the shared edge
       if (X != -1) {
-        int x2z_index{-1}, z2x_index{-1};  // shared edge markers
         if (triples[i][0] == X && triples[i][1] == Z) {
-          x2z_index = 1;
-          z2x_index = 0;
+          w2z_index = 1;
+          z2w_index = 0;
         } else if (triples[i][0] == Z && triples[i][1] == X) {
-          x2z_index = 0;
-          z2x_index = 1;
+          w2z_index = 0;
+          z2w_index = 1;
         } else if (triples[i][2] == X && triples[i][1] == Z) {
-          x2z_index = 2;
-          z2x_index = 3;
+          w2z_index = 2;
+          z2w_index = 3;
         } else if (triples[i][2] == Z && triples[i][1] == X) {
-          x2z_index = 3;
-          z2x_index = 2;
-        }
-        if (x2z_index != -1 && z2x_index != -1) {  // shared edge found
-          const bool inducible = isInducible(x2z.value, latent, propagation);
-          const bool remove_triple = updateScore(
-              x2z_index, z2x_index, x2z.value, z2x.value, inducible, scores[i]);
-          if (remove_triple)
-            i = kRemovalMark;
-          else
-            induceScore(latent, propagation, I3_list[i], scores[i], rank[i]);
+          w2z_index = 3;
+          z2w_index = 2;
         }
       }  // if (X != -1)
-      if (Y != -1 && i != kRemovalMark) {
-        int y2z_index{-1}, z2y_index{-1};  // shared edge markers
+      if (w2z_index != -1 && z2w_index != -1) {  // shared edge found
+        w2z_value = x2z.value;
+        z2w_value = z2x.value;
+      } else if (Y != -1) {
         if (triples[i][0] == Y && triples[i][1] == Z) {
-          y2z_index = 1;
-          z2y_index = 0;
+          w2z_index = 1;
+          z2w_index = 0;
         } else if (triples[i][0] == Z && triples[i][1] == Y) {
-          y2z_index = 0;
-          z2y_index = 1;
+          w2z_index = 0;
+          z2w_index = 1;
         } else if (triples[i][2] == Y && triples[i][1] == Z) {
-          y2z_index = 2;
-          z2y_index = 3;
+          w2z_index = 2;
+          z2w_index = 3;
         } else if (triples[i][2] == Z && triples[i][1] == Y) {
-          y2z_index = 3;
-          z2y_index = 2;
+          w2z_index = 3;
+          z2w_index = 2;
         }
-        if (y2z_index != -1 && z2y_index != -1) {  // shared edge found
-          const bool inducible = isInducible(y2z.value, latent, propagation);
-          const bool remove_triple = updateScore(
-              y2z_index, z2y_index, y2z.value, z2y.value, inducible, scores[i]);
-          if (remove_triple)
-            i = kRemovalMark;
-          else
-            induceScore(latent, propagation, I3_list[i], scores[i], rank[i]);
+        if (w2z_index != -1 && z2w_index != -1) {  // shared edge found
+          w2z_value = y2z.value;
+          z2w_value = z2y.value;
         }
       }  // if (Y != -1)
+      if (w2z_index != -1 && z2w_index != -1) {  // shared edge found
+        const bool inducible = isInducible(w2z_value, latent, propagation);
+        const bool remove_triple = updateScore(
+            w2z_index, z2w_index, w2z_value, z2w_value, inducible, scores[i]);
+        if (remove_triple)
+          i = kRemovalMark;
+        else
+          induceScore(latent, propagation, I3_list[i], scores[i], rank[i]);
+      }
     }  // for (auto i : order)
     order.erase(remove(begin(order), end(order), kRemovalMark), end(order));
   }

--- a/src/proba_orientation.cpp
+++ b/src/proba_orientation.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #define _USE_MATH_DEFINES
 #include <cmath>
+#include <limits>  // std::numeric_limits
 #include <numeric>  // std::iota
 #include <tuple>  // std::tie
 
@@ -14,23 +15,22 @@ using std::fabs;
 
 namespace {
 
-constexpr double kEps = 1.0e-12;
-constexpr double kEpsDiff = 1.0e-12;
 constexpr int kRemoveTripleMark = -1;
+constexpr double kScoreLowest = std::numeric_limits<double>::lowest();
 
-bool isHead(double proba) { return proba > (0.5 + kEps); }
-bool isTail(double proba) { return proba < (0.5 - kEps); }
-bool isOriented(double proba) { return isHead(proba) || isTail(proba); }
+bool isHead(double score) { return score > 0; }  // proba > 0.5
+bool isTail(double score) { return score < 0; }  // proba < 0.5
+bool isOriented(double score) { return isHead(score) || isTail(score); }
 // Given an edge (X px -- py Y) with probabilities px and py, and the value of
 // px(py) is determined, then the value of py(px) can be inferred if
 // 1. px(py) is likely an arrowhead but latent variable (bi-directed edge) is
 //    not allowed.
 // 2. px(py) is likely an arrowtail and propagation of orientation is allowed.
-bool isInferable(double proba, bool latent, bool propagation) {
-  return (isHead(proba) && !latent) || (isTail(proba) && propagation);
+bool isInducible(double score, bool latent, bool propagation) {
+  return (isHead(score) && !latent) || (isTail(score) && propagation);
 }
 
-// Given a Triple t0 (X -- Z -- Y) with the highest log_score, and another
+// Given a Triple t0 (X -- Z -- Y) with the highest score, and another
 // Triple t who shares one edge with t0, and whose probabilities can be updated
 // by those of t0. Suppose the shared edge is W -- Z (W can be X or Y), in the
 // triple t, Z is not necessarily the middle node.
@@ -47,104 +47,93 @@ bool isInferable(double proba, bool latent, bool propagation) {
 // in the ProbaArray of t that corresponds to w2z, z2w, If t is (U -- M -- V),
 // then (w2z_index, z2w_index) is (0, 1) or (1, 0), if t is (V -- M -- U), then
 // (w2z_index, z2w_index) is (2, 3) or (3, 2)
-void updateProba(int w2z_index, int z2w_index, double w2z, double z2w,
-    bool latent, bool propagation, ProbaArray& final, ProbaArray& current,
-    bool& need_propagation, bool& remove_triple) {
-  const bool inferable = isInferable(w2z, latent, propagation);
-
-  final[w2z_index] = w2z;
-  if (inferable) final[z2w_index] = z2w;
+void updateScore(int w2z_index, int z2w_index, double w2z, double z2w,
+    bool inducible, ProbaArray& best, ProbaArray& current,
+    bool& need_induction, bool& remove_triple) {
+  best[w2z_index] = w2z;
+  if (inducible) best[z2w_index] = z2w;
   // If both probabilites of the mid node are already oriented, the triple will
   // not be able to update other triples of lower score in the list.
-  if (isOriented(final[1]) && isOriented(final[2])) {
+  if (isOriented(best[1]) && isOriented(best[2])) {
     remove_triple = true;
   } else {
-    need_propagation = true;
+    need_induction = true;
     // Keep probabilites as the current best, to be later compared with the
     // result of putative propagation.
     current[w2z_index] = w2z;
-    if (inferable) current[z2w_index] = z2w;
+    if (inducible) current[z2w_index] = z2w;
   }
 }
 
 // For an unshielded Triple X -- Z -- Y, given three point mutual infomation
 // I3 = I(X;Y;Z|ui) and probability w2z > 0.5 of orientation from one side node
-// W (X or Y) to Z being a head, return the induced probability v2z (and log
-// proba) of orientation from the other node V (Y or X) to Z
-std::pair<double, double> getInducedProbability(double I3, double w2z) {
+// W (X or Y) to Z being a head, return the induced probability score v2z
+// of orientation from the other node V (Y or X) to Z
+double getInducedScore(double I3, double w2z) {
   // Denote p = 1.0 / (1 + exp(-abs(I3)))
   // If I3 > 0, then p is the probability of non-v-structure W *-> Z --* V, and
-  // v2z = w2z * p is the conditional probability Pr(v2z is tail | w2z is head)
+  // v2z = w2z * p is the probability Pr(v2z is tail), as score.
   // if I3 < 0, then p is the probability of v-structure W *-> Z <-* V, and
-  // v2z = w2z * p is the conditional probability Pr(v2z is head | w2z is head)
-  // Calculate log version first to retain precision in case of large abs(I3)
-  double log_v2z = log1p(w2z - 1) - log1p(exp(-fabs(I3)));
-  return std::make_pair(expm1(log_v2z) + 1, log_v2z);
+  // v2z = w2z * p is the probability Pr(v2z is head), as score.
+  double s_min, s_max;  // structured binding is only available after C++17
+  std::tie(s_min, s_max) = std::minmax(fabs(I3), w2z);
+  return s_min - std::log1p(std::exp(s_min - s_max) + std::exp(-s_max));
 }
 
-// Update score performing putative propagation
-// See Proposition 1.ii and 2 of Verny et al., 2017 (Supplementary Text)
-void propagate(bool latent, bool propagation, double I3,
-    const ProbaArray& final, ProbaArray& current, double& score,
-    double& log_score) {
-  double x2z = final[1], y2z = final[2];
+// Given X *- (x2z) Z (y2z) -* Y, try to induce x2z from y2z, or vice versa.
+// See Proposition 1.ii and 2 of Verny et al., 2017 (Supplementary Text).
+void induceScore(bool latent, bool propagation, double I3,
+    const ProbaArray& best, ProbaArray& current, double& max_score) {
+  double x2z = best[1], y2z = best[2];
   if (I3 > 0) {  // Proposition 2
-    // Define score in case of no true propagation below
-    score = fmax(
-        fmin(current[1], 1 - current[2]), fmin(current[2], 1 - current[1]));
-    log_score = log1p(score - 1);
-    double p_tail{0.5}, logp_tail;
+    // Define score in case of no update below
+    max_score = std::fmax(
+        std::fmin(current[1], -current[2]), std::fmin(current[2], -current[1]));
     if (isHead(x2z)) {  // Try from X *-> Z to Z --* Y
-      std::tie(p_tail, logp_tail) = getInducedProbability(I3, x2z);
-      // Propagate to Z [-]-* Y if no previously higher putative propagation
-      if ((p_tail > 0.5 + kEps) && (current[2] > (1 - p_tail + kEps))) {
-        log_score = logp_tail;
-        score = p_tail;
-        current[2] = 1 - p_tail;
-        // Propagate to Z --[>] Y if no previously higher putative propagation
-        if (propagation && current[3] < (1 - current[2] - kEps))
-          current[3] = 1 - current[2];
+      double s_tail = getInducedScore(I3, x2z);
+      // Update Z [-]-* Y if current proba is less likely a tail
+      if (s_tail > 0 && current[2] > -s_tail) {
+        max_score = s_tail;
+        current[2] = -s_tail;
+        // Update Z --[>] Y if current proba is less likely a head
+        if (propagation && current[3] < -current[2])
+          current[3] = -current[2];
       }
     } else if (isHead(y2z)) {  // Try from Z <-* Y to X *-- Z
-      std::tie(p_tail, logp_tail) = getInducedProbability(I3, y2z);
-      // Propagate to X *-[-] Z if no previously higher putative propagation
-      if ((p_tail > 0.5 + kEps) && (current[1] > (1 - p_tail + kEps))) {
-        log_score = logp_tail;
-        score = p_tail;
-        current[1] = 1 - p_tail;
-        // Propagate to X [<]-- Z if no previously higher putative propagation
-        if (propagation && current[0] < (1 - current[1] - kEps))
-          current[0] = 1 - current[1];
+      double s_tail = getInducedScore(I3, y2z);
+      // Update X *-[-] Z if current proba is less likely a tail
+      if (s_tail > 0 && current[1] > -s_tail) {
+        max_score = s_tail;
+        current[1] = -s_tail;
+        // Update X [<]-- Z if current proba is less likely a head
+        if (propagation && current[0] < -current[1])
+          current[0] = -current[1];
       }
     }
   } else if (I3 < 0) {  // Proposition 1.ii
-    // define score in case of no true propagation below
-    if (fabs(current[1] - current[2]) > kEpsDiff) {
-      score = fmin(current[1], current[2]);
-      log_score = log1p(score - 1);
+    // Define score in case of no update below
+    if (fabs(current[1] - current[2]) > 0) {
+      max_score = std::fmin(current[1], current[2]);
     }
-    double p_head{0.5}, logp_head;
     if (isHead(x2z)) {  // Try from X *-> Z to Z <-* Y
-      std::tie(p_head, logp_head) = getInducedProbability(I3, x2z);
-      // Propagate to Z [<]-* Y if no previously higher putative propagation
-      if ((p_head > 0.5 + kEps) && current[2] < (p_head - kEps)) {
-        log_score = logp_head;
-        score = p_head;
-        current[2] = p_head;
-        // Propagate to Z <-[-] Y if no previously higher putative propagation
-        if (!latent && (current[3] > (1 - current[2] + kEps)))
-          current[3] = 1 - current[2];
+      double s_head = getInducedScore(I3, x2z);
+      // Update Z [<]-* Y if current proba is less likely a head
+      if (s_head > 0 && current[2] < s_head) {
+        max_score = s_head;
+        current[2] = s_head;
+        // Update Z <-[-] Y if current proba is less likely a tail
+        if (!latent && current[3] > -current[2])
+          current[3] = -current[2];
       }
     } else if (isHead(y2z)) {  // Try from Z <-* Y to X *-> Z
-      std::tie(p_head, logp_head) = getInducedProbability(I3, y2z);
-      // Propagate to X *-[>] Z if no previously higher putative propagation
-      if ((p_head > 0.5 + kEps) && (current[1] < (p_head - kEps))) {
-        log_score = logp_head;
-        score = p_head;
-        current[1] = p_head;
-        // Propagate to X [-]-> Z if no previously higher putative propagation
-        if (!latent && (current[0] > (1 - current[1] + kEps)))
-          current[0] = 1 - current[1];
+      double s_head = getInducedScore(I3, y2z);
+      // Update X *-[>] Z if current proba is less likely a head
+      if (s_head > 0 && current[1] < s_head) {
+        max_score = s_head;
+        current[1] = s_head;
+        // Update X [-]-> Z if current proba is less likely a tail
+        if (!latent && current[0] > -current[1])
+          current[0] = -current[1];
       }
     }
   }
@@ -161,157 +150,159 @@ vector<ProbaArray> getOriProbasList(const vector<Triple>& triples,
     const vector<double>& I3_list, const vector<int>& is_contextual,
     bool latent, bool degenerate, bool propagation, bool half_v_structure) {
   int n_triples = triples.size();
-  vector<ProbaArray> probas_final(n_triples);  // to be returned
-  for (auto& p_array : probas_final) p_array.fill(0.5);
+  // A score is a quantity almost proportional to abs(I3). All probabilities
+  // can be expressed in the form of 1 / (1 + exp(-score)), they suffer from
+  // loss of numerical precision for high score due to the exponential term.
+  // Since the mapping between probability and score is bijective, throughout
+  // the orientation process, we will work with scores only.
+  //     score   |--> probability
+  // (-inf, inf) |-->   [0, 1]
+  vector<ProbaArray> scores_best(n_triples);
+  for (auto& s_array : scores_best) s_array.fill(0);  // 0 score <-> 0.5 proba
   // Set initial probability for triples involving contextual variables
   for (int i = 0; i < n_triples; ++i) {
     int X = triples[i][0], Z = triples[i][1], Y = triples[i][2];
-    if (is_contextual[X]) {
-      // X --* Z, X cannot be the child of Z
-      probas_final[i][0] = 0.0;
+    if (is_contextual[X]) {  // X --* Z, X cannot be the child of Z
+      scores_best[i][0] = kScoreLowest;
     }
-    if (is_contextual[Z]) {
-      // X *-- Z, Z cannot be the child of X
-      probas_final[i][1] = 0.0;
-      // Z --* Y, Z cannot be the child of Y
-      probas_final[i][2] = 0.0;
+    if (is_contextual[Z]) {  // X *-- Z --* Y, Z cannot be the child of X or Y
+      scores_best[i][1] = kScoreLowest;
+      scores_best[i][2] = kScoreLowest;
     }
-    if (is_contextual[Y]) {
-      // Z *-- Y, Y cannot be the child of Z
-      probas_final[i][3] = 0.0;
+    if (is_contextual[Y]) {  // Z *-- Y, Y cannot be the child of Z
+      scores_best[i][3] = kScoreLowest;
     }
   }
-  // Keep the current best probas of each triple during the orientation process
-  // Best means most extreme w.r.t. (away from) 0.5
-  auto probas_current = probas_final;  // copy
-  // For a Triple (X, Z, Y), score is initialized as the probability of the
-  // arrowhead Pr(X *-> Z)
-  vector<double> score(n_triples, 0.5);
-  // For dataset with large n_samples, use log score for numerical presicion
-  vector<double> log_score(n_triples, log(0.5));
-  vector<int> orderTpl(n_triples);
-  std::iota(begin(orderTpl), end(orderTpl), 0);
-  // Initialize score and log_score
+  // Keep the current scores of each triple during the orientation process
+  auto scores_current = scores_best;  // copy
+  // Keep the highest absolute value of score of each triple for ordering.
+  vector<double> max_score(n_triples, 0);
   for (int i = 0; i < n_triples; i++) {
-    // Try to propagate any already initialized arrowhead
-    if (isHead(probas_final[i][1]) || isHead(probas_final[i][2])) {
-      propagate(latent, propagation, I3_list[i], probas_final[i],
-          probas_current[i], score[i], log_score[i]);
+    // Try to induce score with already established arrowhead
+    if (isHead(scores_best[i][1]) || isHead(scores_best[i][2])) {
+      induceScore(latent, propagation, I3_list[i], scores_best[i],
+          scores_current[i], max_score[i]);
     } else if (I3_list[i] < 0) {
+      // Initialize scores of v-structure
       if (!degenerate) {
         // if I3_list < 0 (likely a v-structure),
         // Pr(X *-> Z) = Pr(Y *-> Z) = (1 + exp(I3)) / (1 + 3 * exp(I3))
         // See Proposition 1.i of Verny et al., 2017 (Supplementary Text)
-        // use log1p and expm1 to accommodate large N(n_samples) case
-        log_score[i] = log1p(exp(I3_list[i])) - log1p(3 * exp(I3_list[i]));
-        score[i] = expm1(log_score[i]) + 1;
+        max_score[i] = -I3_list[i] - log(2) + std::log1p(std::exp(I3_list[i]));
       } else {
         // larger than p without degenerate
-        score[i] = (3 - 2 * exp(I3_list[i])) / (3 - exp(I3_list[i]));
+        max_score[i] = -I3_list[i] + log(3 - 2 * std::exp(I3_list[i]));
       }
-      probas_current[i][1] = score[i];  // Pr(X *-> Z)
-      probas_current[i][2] = score[i];  // Pr(Y *-> Z)
+      scores_current[i][1] = max_score[i];  // Pr(X *-> Z)
+      scores_current[i][2] = max_score[i];  // Pr(Y *-> Z)
       if (!latent) {
-        probas_current[i][0] = 1 - probas_current[i][1];
-        probas_current[i][3] = 1 - probas_current[i][2];
+        // (p, 1-p) <-> (score, -score)
+        scores_current[i][0] = -scores_current[i][1];
+        scores_current[i][3] = -scores_current[i][2];
       }
     }
   }
 
-  auto compareTriples = [&log_score, &I3_list](int a, int b) {
-    // log scores are non-positive, when the score (proba) is close to 1, i.e.,
-    // when the abs(NI3) is large enough, log score can be subnormal.
-    if (log_score[a] != log_score[b]) {
-      return log_score[a] > log_score[b];
-    } else {
-      return fabs(I3_list[a]) > fabs(I3_list[b]);
-    }
+  auto compareTriples = [&max_score](int a, int b) {
+    return max_score[a] > max_score[b];
   };
 
+  vector<int> orderTpl(n_triples);
+  std::iota(begin(orderTpl), end(orderTpl), 0);
   while (!orderTpl.empty()) {
     // Order triples in decreasing log score
     std::sort(begin(orderTpl), end(orderTpl), compareTriples);
-    int max_idx = orderTpl[0];
-    if (!(score[max_idx] > 0.5 + kEps)) break;
-    orderTpl.erase(begin(orderTpl));  // Remove the triple with max score
+    int top_idx = orderTpl[0];
+    if (max_score[top_idx] <= 0) break;  // top proba <= 0.5
+    orderTpl.erase(begin(orderTpl));  // Remove the top triple
 
-    const auto& max_triple = triples[max_idx];
-    const auto& max_current = probas_current[max_idx];
-    auto& max_final = probas_final[max_idx];
+    const auto& top_triple = triples[top_idx];
+    const auto& top_current = scores_current[top_idx];
+    auto& top_best = scores_best[top_idx];
 
     int X{-1}, Z{-1}, Y{-1};
     // Correspond to ProbaArray[0-3]: *2+, proba of arrowhead from * to +
-    double z2x{0.5}, x2z{0.5}, y2z{0.5}, z2y{0.5};
-    // if arrowhead/tail on Z (x 0-*1 z 2-3 y) is not already established
-    // through an earlier propagation
-    if ((fabs(max_final[1] - 0.5) < (fabs(max_current[1] - 0.5) - kEps)) &&
-        (half_v_structure || I3_list[max_idx] > 0 ||
-            max_final[2] > (0.5 - kEps))) {
+    double z2x{0}, x2z{0}, y2z{0}, z2y{0};
+    // Try updating X 0 -- 1 Z
+    if ((fabs(top_best[1]) < fabs(top_current[1])) &&
+        (half_v_structure || I3_list[top_idx] > 0 || top_best[2] >= 0)) {
       // establish arrowhead/tail final proba on 1 (x 0-*1 z 2-3 y)
-      max_final[1] = max_current[1];
-      if (isInferable(max_final[1], latent, propagation))
-        max_final[0] = max_current[0];
+      top_best[1] = top_current[1];
+      if (isInducible(top_best[1], latent, propagation))
+        top_best[0] = top_current[0];
 
-      X = max_triple[0];
-      Z = max_triple[1];
-      z2x = max_current[0];
-      x2z = max_current[1];
+      X = top_triple[0];
+      Z = top_triple[1];
+      z2x = top_current[0];
+      x2z = top_current[1];
     }
-    if ((fabs(max_final[2] - 0.5) < (fabs(max_current[2] - 0.5) - kEps)) &&
-        (half_v_structure || I3_list[max_idx] > 0 ||
-            max_final[1] > (0.5 - kEps))) {
+    // Try updating Z 2 -- 3 Y
+    if ((fabs(top_best[2]) < fabs(top_current[2])) &&
+        (half_v_structure || I3_list[top_idx] > 0 || top_best[1] >= 0)) {
       // establish arrowhead/tail final proba on 2 (x 0-1 z 2*-3 y)
-      max_final[2] = max_current[2];
-      if (isInferable(max_final[2], latent, propagation))
-        max_final[3] = max_current[3];
+      top_best[2] = top_current[2];
+      if (isInducible(top_best[2], latent, propagation))
+        top_best[3] = top_current[3];
 
-      Z = max_triple[1];
-      Y = max_triple[2];
-      y2z = max_current[2];
-      z2y = max_current[3];
+      Z = top_triple[1];
+      Y = top_triple[2];
+      y2z = top_current[2];
+      z2y = top_current[3];
     }
-    // No new final orientation found, goto next triple
+    // No score updated, goto next triple
     if (X == -1 && Y == -1) continue;
-    // Update probas of all remaining triples with the newly found orientation
+    // Update scores of all remaining triples with scores of the top triple
     for (auto i : orderTpl) {
-      bool need_propagation = false;
       bool remove_triple = false;
       if (X != -1) {
+        int x2z_index{-1}, z2x_index{-1};  // shared edge (scores) markers
         if (triples[i][0] == X && triples[i][1] == Z) {
-          updateProba(1, 0, x2z, z2x, latent, propagation, probas_final[i],
-              probas_current[i], need_propagation, remove_triple);
+          x2z_index = 1;
+          z2x_index = 0;
         } else if (triples[i][0] == Z && triples[i][1] == X) {
-          updateProba(0, 1, x2z, z2x, latent, propagation, probas_final[i],
-              probas_current[i], need_propagation, remove_triple);
+          x2z_index = 0;
+          z2x_index = 1;
         } else if (triples[i][2] == X && triples[i][1] == Z) {
-          updateProba(2, 3, x2z, z2x, latent, propagation, probas_final[i],
-              probas_current[i], need_propagation, remove_triple);
+          x2z_index = 2;
+          z2x_index = 3;
         } else if (triples[i][2] == Z && triples[i][1] == X) {
-          updateProba(3, 2, x2z, z2x, latent, propagation, probas_final[i],
-              probas_current[i], need_propagation, remove_triple);
+          x2z_index = 3;
+          z2x_index = 2;
         }
-        if (need_propagation)
-          propagate(latent, propagation, I3_list[i], probas_final[i],
-              probas_current[i], score[i], log_score[i]);
+        if (x2z_index != -1 && z2x_index != -1) {  // found shared edge
+          const bool inducible = isInducible(x2z, latent, propagation);
+          bool need_induction{false};
+          updateScore(x2z_index, z2x_index, x2z, z2x, inducible, scores_best[i],
+              scores_current[i], need_induction, remove_triple);
+          if (need_induction)
+            induceScore(latent, propagation, I3_list[i], scores_best[i],
+                scores_current[i], max_score[i]);
+        }
       }  // if (X != -1)
-      need_propagation = false;
       if (Y != -1) {
+        int y2z_index{-1}, z2y_index{-1};  // shared edge (scores) markers
         if (triples[i][0] == Y && triples[i][1] == Z) {
-          updateProba(1, 0, y2z, z2y, latent, propagation, probas_final[i],
-              probas_current[i], need_propagation, remove_triple);
+          y2z_index = 1;
+          z2y_index = 0;
         } else if (triples[i][0] == Z && triples[i][1] == Y) {
-          updateProba(0, 1, y2z, z2y, latent, propagation, probas_final[i],
-              probas_current[i], need_propagation, remove_triple);
+          y2z_index = 0;
+          z2y_index = 1;
         } else if (triples[i][2] == Y && triples[i][1] == Z) {
-          updateProba(2, 3, y2z, z2y, latent, propagation, probas_final[i],
-              probas_current[i], need_propagation, remove_triple);
+          y2z_index = 2;
+          z2y_index = 3;
         } else if (triples[i][2] == Z && triples[i][1] == Y) {
-          updateProba(3, 2, y2z, z2y, latent, propagation, probas_final[i],
-              probas_current[i], need_propagation, remove_triple);
+          y2z_index = 3;
+          z2y_index = 2;
         }
-        if (need_propagation)
-          propagate(latent, propagation, I3_list[i], probas_final[i],
-              probas_current[i], score[i], log_score[i]);
+        if (y2z_index != -1 && z2y_index != -1) {  // found shared edge
+          const bool inducible = isInducible(y2z, latent, propagation);
+          bool need_induction{false};
+          updateScore(y2z_index, z2y_index, y2z, z2y, inducible, scores_best[i],
+              scores_current[i], need_induction, remove_triple);
+          if (need_induction)
+            induceScore(latent, propagation, I3_list[i], scores_best[i],
+                scores_current[i], max_score[i]);
+        }
       }  // if (Y != -1)
       if (remove_triple) i = kRemoveTripleMark;
     }  // for (auto i : orderTpl)
@@ -319,7 +310,14 @@ vector<ProbaArray> getOriProbasList(const vector<Triple>& triples,
         end(orderTpl));
   }
 
-  return probas_final;
+  vector<ProbaArray> probas_list(n_triples);
+  for (int i=0; i < n_triples; ++i) {
+    std::transform(begin(scores_best[i]), end(scores_best[i]),
+        begin(probas_list[i]),
+        [](double score) { return 1.0 / (1.0 + std::exp(-score)); });
+  }
+
+  return probas_list;
 }
 
 }  // namespace reconstruction

--- a/src/proba_orientation.h
+++ b/src/proba_orientation.h
@@ -20,6 +20,14 @@ using Triple = std::array<int, 3>;
 // X [0]-[1] Z [2]-[3] Y
 using ProbaArray = std::array<double, 4>;
 
+struct ProbaScore {
+  double value = 0;
+  // An unsettled score can either be updated by another score, or be used to
+  // update other scores.
+  bool settled = false;
+};
+using ScoreArray = std::array<ProbaScore, 4>;
+
 std::vector<ProbaArray> getOriProbasList(const std::vector<Triple>&,
     const std::vector<double>& I3_list, const std::vector<int>& is_contextual,
     bool latent, bool degenerate, bool propagation, bool half_v_structure);


### PR DESCRIPTION
* Use score instead of probability during orientation process.
* Use single list instead of `final` and `current`.
* Simplify functions.
* Update comments.