### PR TITLE
Non negative i prime

### DIFF
--- a/R/miic.R
+++ b/R/miic.R
@@ -176,6 +176,19 @@
 #' When set greater than 1, n_threads parallel threads will be used for computation. Make sure
 #' your compiler is compatible with openmp if you wish to use multithreading.
 #'
+#' @param negative_info [a boolean value] For test purpose only. FALSE by
+#' default. If TRUE, negative shifted mutual information is allowed during the
+#' computation when mutual information is inferior to the complexity term. For
+#' small dateset with complicated structures, e.g., discrete variables with many
+#' levels, allowing for negative shifted mutual information may help identifying
+#' weak v-structures related to those discrete variables, as the negative
+#' three-point information in those cases will come from the difference between
+#' two negative shifted mutual information terms (expected to be negative due to
+#' the small sample size). However, under this setting, a v-structure (X -> Z <-
+#' Y) in the final graph does not necessarily imply that X is dependent on Y
+#' conditioning on Z, As a consequence, the interpretability of the final graph
+#' is hindered. In practice, it's advised to keep this parameter as FALSE.
+#'
 #' @return A \emph{miic-like} object that contains:
 #' \itemize{
 #'  \item{all.edges.summary:}{ a data frame with information about the relationship between
@@ -344,6 +357,7 @@ miic <- function(input_data,
                  consistent = c("no", "orientation", "skeleton"),
                  max_iteration = 100,
                  consensus_threshold = 0.8,
+                 negative_info = FALSE,
                  verbose = FALSE) {
   res <- NULL
 
@@ -566,7 +580,8 @@ miic <- function(input_data,
         sample_weights = sample_weights,
         test_mar = test_mar,
         consistent = consistent,
-        max_iteration = max_iteration
+        max_iteration = max_iteration,
+        negative_info = negative_info
       )
     if (res$interrupted) {
       stop("Interupted by user")

--- a/R/miic.reconstruct.R
+++ b/R/miic.reconstruct.R
@@ -16,7 +16,8 @@ miic.reconstruct <- function(input_data = NULL,
                              sample_weights = NULL,
                              test_mar = TRUE,
                              consistent = "no",
-                             max_iteration = NULL
+                             max_iteration = NULL,
+                             negative_info = FALSE
                              ) {
   n_samples <- nrow(input_data)
   n_nodes <- ncol(input_data)
@@ -69,6 +70,7 @@ miic.reconstruct <- function(input_data = NULL,
     "ori_proba_ratio" = ori_proba_ratio,
     "propagation" = propagation,
     "test_mar" = test_mar,
+    "negative_info" = negative_info,
     "max_bins" = min(50, n_samples),
     "var_names" = var_names,
     "verbose" = verbose

--- a/man/miic.Rd
+++ b/man/miic.Rd
@@ -24,6 +24,7 @@ miic(
   consistent = c("no", "orientation", "skeleton"),
   max_iteration = 100,
   consensus_threshold = 0.8,
+  negative_info = FALSE,
   verbose = FALSE
 )
 }
@@ -48,9 +49,8 @@ variable is to be considered as discrete (0) or continuous (1).
 "levels_increasing_order" (optional) contains a single character string
 with all of the unique levels of the ordinal variable in increasing order,
 delimited by comma ','. It will be used during the post-processing to compute
-the sign of an edge using Spearman's rank correlation. If the variable is
-continuous or is categorical but not ordinal, this column may be left empty
-or contain NA instead.
+the sign of an edge using Spearman's rank correlation. If a variable is
+continuous or is categorical but not ordinal, this column should be NA.
 
 "is_contextual" (optional) contains a binary value that specifies if a
 variable is to be considered as a contextual variable (1) or not (0).
@@ -169,6 +169,19 @@ the proportion of non-zero status (0.6 in the example) is equal to or higher
 than [consensus_threshold]. (When set to connected, the orientation of the
 edge will be further determined by the average probability of orientation.)
 Set to 0.8 by default.}
+
+\item{negative_info}{[a boolean value] For test purpose only. FALSE by
+default. If TRUE, negative shifted mutual information is allowed during the
+computation when mutual information is inferior to the complexity term. For
+small dateset with complicated structures, e.g., discrete variables with many
+levels, allowing for negative shifted mutual information may help identifying
+weak v-structures related to those discrete variables, as the negative
+three-point information in those cases will come from the difference between
+two negative shifted mutual information terms (expected to be negative due to
+the small sample size). However, under this setting, a v-structure (X -> Z <-
+Y) in the final graph does not necessarily imply that X is dependent on Y
+conditioning on Z, As a consequence, the interpretability of the final graph
+is hindered. In practice, it's advised to keep this parameter as FALSE.}
 
 \item{verbose}{[a boolean value] If TRUE, debugging output is printed.}
 }

--- a/src/computation_continuous.cpp
+++ b/src/computation_continuous.cpp
@@ -446,7 +446,7 @@ InfoBlock computeIxy(const TempGrid2d<int>& data,
   }  // for step
 
   // I and Ik can always be 0 by choosing 1 bin on either X or Y.
-  if (Ikxy < 0 && is_continuous[var_idx[0]] && is_continuous[var_idx[1]]) {
+  if (Ikxy < 0) {
     Ixy = 0;
     Ikxy = 0;
   }
@@ -822,7 +822,7 @@ InfoBlock computeIxyui(const TempGrid2d<int>& data,
     Ikxy_ui = cond_Ik;
   }  // for step
   // I and Ik can always be 0 by choosing 1 bin on either X or Y.
-  if (Ikxy_ui < 0 && is_continuous[var_idx[0]] && is_continuous[var_idx[1]]) {
+  if (Ikxy_ui < 0) {
     Ixy_ui = 0;
     Ikxy_ui = 0;
   }

--- a/src/computation_continuous.h
+++ b/src/computation_continuous.h
@@ -17,7 +17,7 @@ structure::InfoBlock computeCondMutualInfo(
     const structure::TempVector<int>& var_idx,
     const structure::TempVector<double>& sample_weights,
     bool flag_sample_weights, int initbins, int maxbins, int cplx,
-    std::shared_ptr<CtermCache>,
+    bool negative_info, std::shared_ptr<CtermCache>,
     std::shared_ptr<structure::CutPointsInfo> = nullptr);
 
 structure::Info3PointBlock computeInfo3PointAndScore(
@@ -28,7 +28,7 @@ structure::Info3PointBlock computeInfo3PointAndScore(
     const structure::TempVector<int>& var_idx,
     const structure::TempVector<double>& sample_weights,
     bool flag_sample_weights, int initbins, int maxbins, int cplx,
-    std::shared_ptr<CtermCache> cache);
+    bool negative_info, std::shared_ptr<CtermCache> cache);
 
 }  // namespace computation
 }  // namespace miic

--- a/src/computation_discrete.cpp
+++ b/src/computation_discrete.cpp
@@ -20,7 +20,7 @@ using miic::utility::TempAllocatorScope;
 
 InfoBlock computeCondMutualInfoDiscrete(const TempGrid2d<int>& data,
     const TempVector<int>& r_list, const TempVector<int>& var_idx,
-    const TempVector<double>& weights, int cplx,
+    const TempVector<double>& weights, int cplx, bool negative_info,
     std::shared_ptr<CtermCache> cache) {
   TempAllocatorScope scope;
 
@@ -126,8 +126,7 @@ InfoBlock computeCondMutualInfoDiscrete(const TempGrid2d<int>& data,
 
   double Ixy_ui = Hux + Huy - Hu - Huyx;
   double kxy_ui = 0.5 * (logC_ux_y - logC_u_y + logC_uy_x - logC_u_x);
-  // I and k can always be 0 by choosing 1 bin on either X or Y.
-  if (Ixy_ui - kxy_ui < 0) {
+  if (!negative_info && Ixy_ui - kxy_ui < 0) {
     Ixy_ui = 0;
     kxy_ui = 0;
   }
@@ -137,7 +136,7 @@ InfoBlock computeCondMutualInfoDiscrete(const TempGrid2d<int>& data,
 
 Info3PointBlock computeInfo3PointAndScoreDiscrete(const TempGrid2d<int>& data,
     const TempVector<int>& r_list, const TempVector<int>& var_idx,
-    const TempVector<double>& weights, int cplx,
+    const TempVector<double>& weights, int cplx, bool negative_info,
     std::shared_ptr<CtermCache> cache) {
   TempAllocatorScope scope;
 
@@ -307,25 +306,25 @@ Info3PointBlock computeInfo3PointAndScoreDiscrete(const TempGrid2d<int>& data,
 
   double info_xy_ui = Hux + Huy - Hu - Huyx;
   double logC_xy_ui = 0.5 * (logC_ux_y - logC_u_y + logC_uy_x - logC_u_x);
-  if (info_xy_ui - logC_xy_ui < 0) {
+  if (!negative_info && info_xy_ui - logC_xy_ui < 0) {
     info_xy_ui = 0;
     logC_xy_ui = 0;
   }
   double info_yz_ui = Huy + Hzu - Hu - Hzuy;
   double logC_yz_ui = 0.5 * (logC_zu_y - logC_u_y + logC_uy_z - logC_u_z);
-  if (info_yz_ui - logC_yz_ui < 0) {
+  if (!negative_info && info_yz_ui - logC_yz_ui < 0) {
     info_yz_ui = 0;
     logC_yz_ui = 0;
   }
   double info_xz_ui = Hux + Hzu - Hu - Hzux;
   double logC_xz_ui = 0.5 * (logC_zu_x - logC_u_x + logC_ux_z - logC_u_z);
-  if (info_xz_ui - logC_xz_ui < 0) {
+  if (!negative_info && info_xz_ui - logC_xz_ui < 0) {
     info_xz_ui = 0;
     logC_xz_ui = 0;
   }
   double info_xy_uiz = Hzux + Hzuy - Hzu - Hzuyx;
   double logC_xy_uiz = 0.5 * (logC_zux_y - logC_zu_y + logC_zuy_x - logC_zu_x);
-  if (info_xy_uiz - logC_xy_uiz < 0) {
+  if (!negative_info && info_xy_uiz - logC_xy_uiz < 0) {
     info_xy_uiz = 0;
     logC_xy_uiz = 0;
   }

--- a/src/computation_discrete.cpp
+++ b/src/computation_discrete.cpp
@@ -126,6 +126,11 @@ InfoBlock computeCondMutualInfoDiscrete(const TempGrid2d<int>& data,
 
   double Ixy_ui = Hux + Huy - Hu - Huyx;
   double kxy_ui = 0.5 * (logC_ux_y - logC_u_y + logC_uy_x - logC_u_x);
+  // I and k can always be 0 by choosing 1 bin on either X or Y.
+  if (Ixy_ui - kxy_ui < 0) {
+    Ixy_ui = 0;
+    kxy_ui = 0;
+  }
 
   return InfoBlock{N_total, Ixy_ui, kxy_ui};
 }
@@ -302,12 +307,28 @@ Info3PointBlock computeInfo3PointAndScoreDiscrete(const TempGrid2d<int>& data,
 
   double info_xy_ui = Hux + Huy - Hu - Huyx;
   double logC_xy_ui = 0.5 * (logC_ux_y - logC_u_y + logC_uy_x - logC_u_x);
+  if (info_xy_ui - logC_xy_ui < 0) {
+    info_xy_ui = 0;
+    logC_xy_ui = 0;
+  }
   double info_yz_ui = Huy + Hzu - Hu - Hzuy;
   double logC_yz_ui = 0.5 * (logC_zu_y - logC_u_y + logC_uy_z - logC_u_z);
+  if (info_yz_ui - logC_yz_ui < 0) {
+    info_yz_ui = 0;
+    logC_yz_ui = 0;
+  }
   double info_xz_ui = Hux + Hzu - Hu - Hzux;
   double logC_xz_ui = 0.5 * (logC_zu_x - logC_u_x + logC_ux_z - logC_u_z);
+  if (info_xz_ui - logC_xz_ui < 0) {
+    info_xz_ui = 0;
+    logC_xz_ui = 0;
+  }
   double info_xy_uiz = Hzux + Hzuy - Hzu - Hzuyx;
   double logC_xy_uiz = 0.5 * (logC_zux_y - logC_zu_y + logC_zuy_x - logC_zu_x);
+  if (info_xy_uiz - logC_xy_uiz < 0) {
+    info_xy_uiz = 0;
+    logC_xy_uiz = 0;
+  }
 
   double xz = (info_xz_ui - logC_xz_ui) - (info_xy_ui - logC_xy_ui);
   double yz  = (info_yz_ui - logC_yz_ui) - (info_xy_ui - logC_xy_ui);

--- a/src/computation_discrete.h
+++ b/src/computation_discrete.h
@@ -12,12 +12,12 @@ structure::InfoBlock computeCondMutualInfoDiscrete(
     const structure::TempVector<int>& r_list,
     const structure::TempVector<int>& var_idx,
     const structure::TempVector<double>& weights, int cplx,
-    std::shared_ptr<CtermCache> cache);
+    bool negative_info, std::shared_ptr<CtermCache> cache);
 structure::Info3PointBlock computeInfo3PointAndScoreDiscrete(
     const structure::TempGrid2d<int>& data,
     const structure::TempVector<int>& r_list,
     const structure::TempVector<int>& var_idx,
-    const structure::TempVector<double>& weights, int cplx,
+    const structure::TempVector<double>& weights, int cplx, bool negative_info,
     std::shared_ptr<CtermCache> cache);
 
 }  // namespace computation

--- a/src/environment.h
+++ b/src/environment.h
@@ -68,6 +68,8 @@ struct Environment {
   bool degenerate = false;
   bool no_init_eta = false;
   bool half_v_structure = false;
+  // If true, allow for negative shifted mutual information
+  bool negative_info = false;
 
   int maxbins = 50;
   int initbins;

--- a/src/get_information.cpp
+++ b/src/get_information.cpp
@@ -125,12 +125,13 @@ double getInfo3PointOrScore(Environment& environment, int X, int Y, int Z,
   if (std::all_of(begin(is_continuous_red), end(is_continuous_red),
           [](int x) { return x == 0; })) {
     res = computeInfo3PointAndScoreDiscrete(data_red, levels_red, var_idx_red,
-        weights_red, environment.cplx, environment.cache.cterm);
+        weights_red, environment.cplx, environment.negative_info,
+        environment.cache.cterm);
   } else {
     res = computeInfo3PointAndScore(data_red, data_idx_red, levels_red,
         is_continuous_red, var_idx_red, weights_red, flag_sample_weights,
         environment.initbins, environment.maxbins, environment.cplx,
-        environment.cache.cterm);
+        environment.negative_info, environment.cache.cterm);
   }
   double info = res.Ixyz_ui - res.kxyz_ui;  // I(x;y;z|u) - cplx I(x;y;z|u)
   double score = res.score;                 // R(X,Y;Z|ui)
@@ -205,12 +206,13 @@ InfoBlock getCondMutualInfo(int X, int Y, const vector<int>& ui_list,
   if (std::all_of(begin(is_continuous_red), end(is_continuous_red),
           [](int x) { return x == 0; })) {
     res = computeCondMutualInfoDiscrete(data_red, levels_red, var_idx_red,
-        weights_red, environment.cplx, environment.cache.cterm);
+        weights_red, environment.cplx, environment.negative_info,
+        environment.cache.cterm);
   } else {
     res = computeCondMutualInfo(data_red, data_idx_red, levels_red,
         is_continuous_red, var_idx_red, weights_red, flag_sample_weights,
         environment.initbins, environment.maxbins, environment.cplx,
-        environment.cache.cterm);
+        environment.negative_info, environment.cache.cterm);
   }
   if (std::fabs(res.I) < kPrecision) res.I = 0;
   if (std::fabs(res.k) < kPrecision) res.k = 0;
@@ -291,12 +293,13 @@ double getEntropy(Environment& environment, int Z, int X, int Y) {
             [](int x) { return x == 0; })) {
       res = computeCondMutualInfoDiscrete(part_data_red, part_levels_red,
           part_var_idx_red, weights_red, environment.cplx,
-          environment.cache.cterm);
+          environment.negative_info, environment.cache.cterm);
     } else {
       res = computeCondMutualInfo(part_data_red, part_data_idx_red,
-          part_levels_red, part_is_continuous_red, part_var_idx_red, weights_red,
-          flag_sample_weights, environment.initbins, environment.maxbins,
-          environment.cplx, environment.cache.cterm);
+          part_levels_red, part_is_continuous_red, part_var_idx_red,
+          weights_red, flag_sample_weights, environment.initbins,
+          environment.maxbins, environment.cplx, environment.negative_info,
+          environment.cache.cterm);
     }
     if (std::fabs(res.I) < kPrecision) res.I = 0;
     if (std::fabs(res.k) < kPrecision) res.k = 0;

--- a/src/mdl_pair_discretize.cpp
+++ b/src/mdl_pair_discretize.cpp
@@ -70,7 +70,7 @@ List mydiscretizeMutual(List input_data, List arg_list) {
   computeCondMutualInfo(dataNumeric_red, dataNumericIdx_red, AllLevels_red,
       cnt_red, posArray_red, sample_weights_red, flag_sample_weights,
       environment.initbins, environment.maxbins, environment.cplx,
-      environment.cache.cterm, cuts_ptr);
+      environment.negative_info, environment.cache.cterm, cuts_ptr);
 
   int niterations = cuts_ptr->n_iterations;
   TempGrid2d<int> iterative_cuts(kStepMax * maxbins, 2);

--- a/src/r_cpp_interface.cpp
+++ b/src/r_cpp_interface.cpp
@@ -119,6 +119,9 @@ void setEnvironmentFromR(const Rcpp::List& input_data,
   omp_set_num_threads(environment.n_threads);
 #endif
 
+  if (arg_list.containsElementNamed("negative_info"))
+    environment.negative_info = as<bool>(arg_list["negative_info"]);
+
   if (arg_list.containsElementNamed("verbose"))
     environment.verbose = as<bool>(arg_list["verbose"]);
 


### PR DESCRIPTION
Now by default, shifted mutual information is non-negative. If the parameter `negative_info` is set to `TRUE`, negative shifted mutual information is allowed during the computation when mutual information is inferior to the complexity term. For small dateset with complicated structures, e.g., discrete variables with many levels, allowing for negative shifted mutual information may help identifying weak v-structures related to those discrete variables, as the negative three-point information in those cases will come from the difference between two negative shifted mutual information terms (expected to be negative due to the small sample size). However, under this setting, a v-structure (X -> Z <- Y) in the final graph does not necessarily imply that X is dependent on Y conditioning on Z, As a consequence, the interpretability of the final graph is hindered. In practice, it's advised to keep this parameter as `FALSE`.