### PR TITLE
Redefine the skeleton consistency algorithm.

### DIFF
--- a/src/biconnected_component.cpp
+++ b/src/biconnected_component.cpp
@@ -51,6 +51,10 @@ void BiconnectedComponent::setCandidateZ(int x, int y, vector<int>& zi_list) {
     auto set_z = getCandidateZ(x, y);
     auto is_consistent = [this, x, y](int z){
       if (latent_) return true;
+      // For double arrow headed edge (x <-> z), z is considered consistent
+      if ((edges_(x, z).status_prev == 2 && edges_(z, x).status_prev == 2) ||
+          (edges_(y, z).status_prev == 2 && edges_(z, y).status_prev == 2))
+        return true;
       // status is either 0 (not connected) or 2 (z is the child of x or y)
       if (edges_(x, z).status_prev != 1 && edges_(y, z).status_prev != 1)
         return false;
@@ -76,6 +80,10 @@ bool BiconnectedComponent::isConsistent(
     // Not in the consistent set
     if (set_z.find(z) == set_z.end())
       return false;
+    // For double arrow headed edge (x <-> z), z is considered consistent
+    if ((edges_(x, z).status == 2 && edges_(z, x).status == 2) ||
+        (edges_(y, z).status == 2 && edges_(z, y).status == 2))
+      continue;
     // status is either 0 (not connected) or 2 (z is the child of x or y)
     if (edges_(x, z).status != 1 && edges_(y, z).status != 1)
       return false;

--- a/src/biconnected_component.cpp
+++ b/src/biconnected_component.cpp
@@ -47,10 +47,11 @@ set<int> BiconnectedComponent::getCandidateZ(int x, int y) const {
 
 void BiconnectedComponent::setCandidateZ(int x, int y, vector<int>& zi_list) {
   zi_list.clear();
-  if (consistent_) {
+  if (consistent_ != 0) {
     auto set_z = getCandidateZ(x, y);
     auto is_consistent = [this, x, y](int z){
-      if (latent_) return true;
+      // consistent_ -> 1: orientation consistency; 2: skeleton consistency
+      if (latent_ || consistent_ == 2) return true;
       // For double arrow headed edge (x <-> z), z is considered consistent
       if ((edges_(x, z).status_prev == 2 && edges_(z, x).status_prev == 2) ||
           (edges_(y, z).status_prev == 2 && edges_(z, y).status_prev == 2))
@@ -80,6 +81,9 @@ bool BiconnectedComponent::isConsistent(
     // Not in the consistent set
     if (set_z.find(z) == set_z.end())
       return false;
+    // consistent_ -> 1: orientation consistency; 2: skeleton consistency
+    if (consistent_ == 2)
+      continue;
     // For double arrow headed edge (x <-> z), z is considered consistent
     if ((edges_(x, z).status == 2 && edges_(z, x).status == 2) ||
         (edges_(y, z).status == 2 && edges_(z, y).status == 2))

--- a/src/biconnected_component.h
+++ b/src/biconnected_component.h
@@ -21,7 +21,7 @@ using namespace miic::utility;
 
 class BiconnectedComponent {
  public:
-  BiconnectedComponent(const Grid2d<Edge>& edges, bool consistent, bool latent)
+  BiconnectedComponent(const Grid2d<Edge>& edges, int consistent, bool latent)
       : edges_(edges),
         n_nodes_(edges.n_rows()),
         consistent_(consistent),
@@ -54,7 +54,7 @@ class BiconnectedComponent {
  private:
   const Grid2d<Edge>& edges_;
   const int n_nodes_;
-  const bool consistent_;
+  const int consistent_;
   const bool latent_;
   vector<int> is_cut_point_;
   vector<int> degree_of_;

--- a/src/environment.h
+++ b/src/environment.h
@@ -34,8 +34,8 @@ struct Environment {
   bool propagation = false;
   // Level of consistency required for the graph
   // 0: no consistency requirement
-  // 1: skeleton consistent
-  // 2: orientation consistent
+  // 1: orientation consistent
+  // 2: skeleton consistent
   int consistent = 0;
   // When consistent > 0, the maximum number of iterations allowed when trying
   // to find a consistent graph.


### PR DESCRIPTION
* The new skeleton consistency algorithm now differs from the
  orientation consistency algorithm only in the definition of consistency.
  When the parameter `consistent` is set to `skeleton`:
- The graph will be oriented during each iteration;
- A candidate conditioning node will be considered as consistent as long
  as it is on at least one path connecting both end nodes of interest,
  regardless of the orientations of the edges or whether the candidate
  node is within the neighborhood of the end nodes.
* Fix comments in `environment.h`.
* Conditioning nodes involving bi-directed edges are now considered
consistent again.