### PR TITLE
Revert "Use threadprivate and raw pointer for li_alloc_ptr"

### DIFF
--- a/src/linear_allocator.cpp
+++ b/src/linear_allocator.cpp
@@ -3,24 +3,7 @@
 namespace miic {
 namespace utility {
 namespace detail {
-
-void* align(size_t alignment, size_t size, void*& ptr, size_t& space) {
-  void* r = nullptr;
-  if (size <= space) {
-    char* p1 = static_cast<char*>(ptr);
-    char* p2 = reinterpret_cast<char*>(
-        reinterpret_cast<size_t>(p1 + (alignment - 1)) & -alignment);
-    size_t d = static_cast<size_t>(p2 - p1);
-    if (d <= space - size) {
-      r = p2;
-      ptr = r;
-      space -= d;
-    }
-  }
-  return r;
-}
-
-LinearAllocator* li_alloc_ptr = nullptr;
+thread_local std::unique_ptr<LinearAllocator> li_alloc_ptr;
 }  // namespace detail
 }  // namespace utility
 }  // namespace miic

--- a/src/linear_allocator.cpp
+++ b/src/linear_allocator.cpp
@@ -3,6 +3,23 @@
 namespace miic {
 namespace utility {
 namespace detail {
+
+void* align(size_t alignment, size_t size, void*& ptr, size_t& space) {
+  void* r = nullptr;
+  if (size <= space) {
+    char* p1 = static_cast<char*>(ptr);
+    char* p2 = reinterpret_cast<char*>(
+        reinterpret_cast<size_t>(p1 + (alignment - 1)) & -alignment);
+    size_t d = static_cast<size_t>(p2 - p1);
+    if (d <= space - size) {
+      r = p2;
+      ptr = r;
+      space -= d;
+    }
+  }
+  return r;
+}
+
 thread_local std::unique_ptr<LinearAllocator> li_alloc_ptr;
 }  // namespace detail
 }  // namespace utility

--- a/src/linear_allocator.h
+++ b/src/linear_allocator.h
@@ -8,10 +8,6 @@
 #ifndef MIIC_LINEAR_ALLOCATOR_H
 #define MIIC_LINEAR_ALLOCATOR_H
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
 #include <cassert>
 #include <cstdlib>  // std::malloc, std::free, std::size_t
 #include <memory>   // std::unique_ptr
@@ -64,10 +60,7 @@ class LinearAllocator {
   size_t m_free_space_;
 };
 
-extern LinearAllocator* li_alloc_ptr;
-#ifdef _OPENMP
-#pragma omp threadprivate(li_alloc_ptr)
-#endif
+extern thread_local std::unique_ptr<LinearAllocator> li_alloc_ptr;
 
 template <typename T>
 struct TempStdAllocator {

--- a/src/mdl_pair_discretize.cpp
+++ b/src/mdl_pair_discretize.cpp
@@ -37,7 +37,7 @@ List mydiscretizeMutual(List input_data, List arg_list) {
   size_t li_alloc_size = getLinearAllocatorSize(environment.n_samples,
       environment.n_nodes, maxbins, environment.initbins,
       environment.is_continuous, environment.levels);
-  li_alloc_ptr = new LinearAllocator(li_alloc_size);
+  li_alloc_ptr = std::make_unique<LinearAllocator>(li_alloc_size);
 
   vector<int> ui_list(environment.n_nodes - 2);
   std::iota(begin(ui_list), end(ui_list), 2);
@@ -116,6 +116,5 @@ List miicRGetInfo3Point(List input_data, List arg_list) {
       _["I2"]            = res.Ixy_ui,
       _["I2k"]           = res.Ixy_ui - res.kxy_ui);
 
-  delete li_alloc_ptr;
   return result;
 }

--- a/src/mdl_pair_discretize.cpp
+++ b/src/mdl_pair_discretize.cpp
@@ -83,7 +83,6 @@ List mydiscretizeMutual(List input_data, List arg_list) {
     result.push_back(cuts_ptr->I_equal_freq_max, "efinfo");
   }
 
-  delete li_alloc_ptr;
   return result;
 }
 
@@ -103,7 +102,7 @@ List miicRGetInfo3Point(List input_data, List arg_list) {
   size_t li_alloc_size = getLinearAllocatorSize(environment.n_samples,
       environment.n_nodes, maxbins, environment.initbins,
       environment.is_continuous, environment.levels);
-  li_alloc_ptr = new LinearAllocator(li_alloc_size);
+  li_alloc_ptr = std::make_unique<LinearAllocator>(li_alloc_size);
 
   vector<int> ui_list(environment.n_nodes - 3);
   std::iota(begin(ui_list), end(ui_list), 3);

--- a/src/reconstruct.cpp
+++ b/src/reconstruct.cpp
@@ -45,7 +45,7 @@ List reconstruct(List input_data, List arg_list) {
 #ifdef _OPENMP
 #pragma omp parallel  // each thread has its own instance of li_alloc_ptr
 #endif
-  li_alloc_ptr = new LinearAllocator(li_alloc_size);
+  li_alloc_ptr = std::make_unique<LinearAllocator>(li_alloc_size);
 
   // Start reconstruction
   auto lap_start = getLapStartTime();
@@ -133,6 +133,5 @@ List reconstruct(List input_data, List arg_list) {
         cycle_tracker.getProbaAdjMatrices(size), "proba_adj_matrices");
     result.push_back(is_consistent, "is_consistent");
   }
-  delete li_alloc_ptr;
   return result;
 }


### PR DESCRIPTION
This reverts commit d0bf1cf574d2e8e2f2e61e45fadb6519c11d3ca7.

Testing what was proposed at #122 by @honghaoli42.
