### PR TITLE
Fix factor conversion of mixed input data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # v2.0.4
 
+## Fixes and improvements
+
+* Fix factor conversion of mixed input data
+
 * Memory optimization 
 
 ## Known issues

--- a/R/miic.reconstruct.R
+++ b/R/miic.reconstruct.R
@@ -26,7 +26,7 @@ miic.reconstruct <- function(input_data = NULL,
   n_samples <- nrow(input_data)
   n_nodes <- ncol(input_data)
   # Numeric factor matrix, level starts from 0, NA mapped to -1
-  input_factor <- apply(input_data, 2, function(x)
+  input_factor <- sapply(input_data, function(x)
                         (as.numeric(factor(x, levels = unique(x))) - 1))
   input_factor[is.na(input_factor)] <- -1
   max_level_list <- as.numeric(apply(input_factor, 2, max)) + 1


### PR DESCRIPTION
**Test case:**
library (miic)
{
set.seed(0)
df = data.frame ("X"=rnorm (100000), "Letters"=sample (LETTERS, 100000, replace=T), stringsAsFactors=F)
df$Y = log (abs (df$X) + 1) + rnorm (100000, sd=0.1)
head (df)
cmi_obj = computeMutualInfo(df$X, df$Y)
cat ("computeMutualInfo:\n")
cat (paste0 ("- info : ", cmi_obj$info, "\n") )
cat (paste0 ("- infok: ", cmi_obj$infok, "\n") )
mo = miic (df)
cat ("MIIC:\n")
print (mo$summary[1, c("x", "y", "ai", "info", "info_shifted")])
}       

**Before fix**
computeMutualInfo:
- info : 114250.559936407
- infok: 111448.36527357
Search all pairs for unconditional independence relations...
Search for candidate separating nodes...
[========================================] 100% eta: 0s        
Search for edge directions...
Number of edges: 1
MIIC:
  x y   ai     info info_shifted
1 X Y <NA> 114288.7     111437.9

**After fix**
computeMutualInfo:
- info : 114250.559936407
- infok: 111448.36527357
Search all pairs for unconditional independence relations...
Search for candidate separating nodes...
[========================================] 100% eta: 0s        
Search for edge directions...
Number of edges: 1
MIIC:
  x y   ai     info info_shifted
1 X Y <NA> 114250.6     111448.4
